### PR TITLE
Only register std::ffi::OsString where it's available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ mod collect {
     register_serialize_external!(char, "9786a9f4-1195-4dd1-875d-3e469454d9c4");
     register_serialize_external!(String, "7edbc10a-2147-499c-af9a-498723c7b35f");
     register_serialize_external!(std::ffi::CString, "d26a39da-d0e2-46b1-aeab-481fe57d0f23");
+    #[cfg(any(unix, windows))]
     register_serialize_external!(std::ffi::OsString, "38485fce-f5d0-48df-b5cb-98e510c26a8d");
     register_serialize_external!(std::num::NonZeroU8, "284b98ec-ecb5-463c-9744-23b8669c5553");
     register_serialize_external!(std::num::NonZeroU16, "38f030e4-6046-45c9-96b4-1830b1aa3f35");


### PR DESCRIPTION
Compilation for `wasm` fails with the below exception. https://docs.serde.rs/src/serde/ser/impls.rs.html#816-823 shows that Serde only supports `std::ffi::OsString` for Windows and Unix targets. This notably excludes Webassembly. This PR brings over the `#[cfg(...)]` annotation that Serde uses for `OsString`. There is the risk of drift, but any failures should be compile-time, so maybe not a *huge* issue.

With this change, `legion_typeuuid` compiles cleanly for `wasm`.

```
error[E0277]: the trait bound `for<'de> OsString: Deserialize<'de>` is not satis
fied
   --> C:\Users\abesto\.cargo\git\checkouts\legion_typeuuid-a066832a5d711849\c69
979e\src\lib.rs:181:34
    |
181 |                         registry.register::<$component>(id);
    |                                  ^^^^^^^^ the trait `for<'de> Deserialize<
'de>` is not implemented for `OsString`
...
206 |     register_serialize_external!(std::ffi::OsString, "38485fce-f5d0-48df-b
5cb-98e510c26a8d");
    |     ----------------------------------------------------------------------
------------------- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z mac
ro-backtrace for more info)

error[E0277]: the trait bound `OsString: Serialize` is not satisfied
   --> C:\Users\abesto\.cargo\git\checkouts\legion_typeuuid-a066832a5d711849\c69
979e\src\lib.rs:181:34
    |
181 |                         registry.register::<$component>(id);
    |                                  ^^^^^^^^ the trait `Serialize` is not imp
lemented for `OsString`
...
206 |     register_serialize_external!(std::ffi::OsString, "38485fce-f5d0-48df-b
5cb-98e510c26a8d");
    |     ----------------------------------------------------------------------
------------------- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z mac
ro-backtrace for more info)

error: aborting due to 2 previous errors
```